### PR TITLE
defs, state: fallible

### DIFF
--- a/interfaces/Cargo.lock
+++ b/interfaces/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +590,7 @@ dependencies = [
 name = "interfaces"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "futures",
  "sqlx",
  "tokio",

--- a/interfaces/Cargo.toml
+++ b/interfaces/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1.0.99"
 futures = "0.3.31"
 sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "migrate"] }
 tokio = { version = "1", features = ["full"] }

--- a/interfaces/src/defs.rs
+++ b/interfaces/src/defs.rs
@@ -1,3 +1,5 @@
+use anyhow::Result;
+
 pub struct LiveSourceSpec {
     pub uri: String,
 }
@@ -26,7 +28,7 @@ pub trait Ingester {
     ///
     /// When there's nothing to be done for a while, return with a
     /// [`WatchRest`] specifying how long to wait before checking again.
-    fn watch(source: &LiveSourceSpec) -> impl Future<Output = WatchRest>;
+    fn watch(source: &LiveSourceSpec) -> impl Future<Output = Result<WatchRest>>;
 }
 
 pub struct DigestPreferences {
@@ -69,8 +71,8 @@ pub struct DigestOutput {
 // method.
 
 pub trait DigestModel {
-    fn digest(spec: &DigestModelSpec, memory: &DigestModelMemory, preferences: &DigestPreferences, input_items: &[InputItem]) -> impl Future<Output = DigestOutput>;
-    fn reflect(spec: &DigestModelSpec, memory: &DigestModelMemory, preferences: &DigestPreferences, input_items: &[InputItem], self_output: &DigestOutput, opponent_output: &DigestOutput, win: bool) -> impl Future<Output = DigestModelMemory>;
+    fn digest(spec: &DigestModelSpec, memory: &DigestModelMemory, preferences: &DigestPreferences, input_items: &[InputItem]) -> impl Future<Output = Result<DigestOutput>>;
+    fn reflect(spec: &DigestModelSpec, memory: &DigestModelMemory, preferences: &DigestPreferences, input_items: &[InputItem], self_output: &DigestOutput, opponent_output: &DigestOutput, win: bool) -> impl Future<Output = Result<DigestModelMemory>>;
 }
 
 pub struct DigestAttempt {

--- a/interfaces/src/empty.rs
+++ b/interfaces/src/empty.rs
@@ -1,3 +1,5 @@
+use anyhow::Result;
+
 use crate::defs::DigestModel;
 use crate::defs::DigestModelMemory;
 use crate::defs::DigestModelSpec;
@@ -8,18 +10,18 @@ use crate::defs::InputItem;
 pub struct EmptyDigestModel;
 
 impl DigestModel for EmptyDigestModel {
-    async fn digest(spec: &DigestModelSpec, memory: &DigestModelMemory, preferences: &DigestPreferences, input_items: &[InputItem]) -> DigestOutput {
+    async fn digest(spec: &DigestModelSpec, memory: &DigestModelMemory, preferences: &DigestPreferences, input_items: &[InputItem]) -> Result<DigestOutput> {
         _ = spec;
         _ = memory;
         _ = preferences;
         _ = input_items;
         // Nothing matters, the ideal digest is empty.
-        DigestOutput {
+        Ok(DigestOutput {
             selected_items: vec![],
             text: "".to_owned(),
-        }
+        })
     }
-    async fn reflect(spec: &DigestModelSpec, memory: &DigestModelMemory, preferences: &DigestPreferences, input_items: &[InputItem], self_output: &DigestOutput, opponent_output: &DigestOutput, win: bool) -> DigestModelMemory {
+    async fn reflect(spec: &DigestModelSpec, memory: &DigestModelMemory, preferences: &DigestPreferences, input_items: &[InputItem], self_output: &DigestOutput, opponent_output: &DigestOutput, win: bool) -> Result<DigestModelMemory> {
         _ = spec;
         _ = memory;
         _ = preferences;
@@ -28,8 +30,8 @@ impl DigestModel for EmptyDigestModel {
         _ = opponent_output;
         _ = win;
         // Learn nothing, leave the memory as is.
-        DigestModelMemory {
+        Ok(DigestModelMemory {
             text: memory.text.clone(),
-        }
+        })
     }
 }

--- a/interfaces/src/main.rs
+++ b/interfaces/src/main.rs
@@ -15,13 +15,13 @@ pub mod empty;
 pub mod state;
 
 #[tokio::main]
-async fn main() {
-    state::migrate().await;
+async fn main() -> anyhow::Result<()> {
+    state::migrate().await?;
 
     let live_source_spec = LiveSourceSpec {
         uri: "tag:summarena.pages.dev,2025-08:live_source/dummy".to_owned(),
     };
-    state::create_live_source_spec(&live_source_spec).await;
+    state::create_live_source_spec(&live_source_spec).await?;
 
     let item0_uri = "tag:summarena.pages.dev,2025-08:input_item/dummy/sample_text";
     let item0_text = "Hello, world!";
@@ -34,7 +34,7 @@ async fn main() {
         },
     ];
     for input_item in &input_items {
-        state::ingest(input_item).await;
+        state::ingest(input_item).await?;
     }
 
     let spec = DigestModelSpec {
@@ -47,7 +47,7 @@ async fn main() {
         uri: "tag:summarena.pages.dev,2025-08:digest_preferences/empty".to_owned(),
         description: "".to_owned(),
     };
-    let output = BaselineDigestModel::digest(&spec, &memory_in, &preferences, &input_items).await;
+    let output = BaselineDigestModel::digest(&spec, &memory_in, &preferences, &input_items).await?;
     println!("output: {:#?}", &output);
     let other_output = DigestOutput {
         selected_items: vec![
@@ -62,6 +62,7 @@ async fn main() {
         ],
         text: "They said the usual hello world".to_owned(),
     };
-    let memory_out = BaselineDigestModel::reflect(&spec, &memory_in, &preferences, &input_items, &output, &other_output, true).await;
+    let memory_out = BaselineDigestModel::reflect(&spec, &memory_in, &preferences, &input_items, &output, &other_output, true).await?;
     println!("memory_out: {:#?}", &memory_out);
+    Ok(())
 }

--- a/interfaces/src/state.rs
+++ b/interfaces/src/state.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use sqlx::Connection;
 use sqlx::SqliteConnection;
 use sqlx::migrate::MigrateDatabase;
@@ -5,18 +6,19 @@ use sqlx::migrate::MigrateDatabase;
 use crate::defs::InputItem;
 use crate::defs::LiveSourceSpec;
 
-async fn get_db_connection() -> SqliteConnection {
-    SqliteConnection::connect("sqlite:omni.db").await.unwrap()
+async fn get_db_connection() -> Result<SqliteConnection> {
+    Ok(SqliteConnection::connect("sqlite:omni.db").await?)
 }
 
-pub async fn migrate() {
-    sqlx::Sqlite::create_database("sqlite:omni.db").await.unwrap();
-    let mut conn = get_db_connection().await;
-    sqlx::migrate!("./migrations").run(&mut conn).await.unwrap();
+pub async fn migrate() -> Result<()> {
+    sqlx::Sqlite::create_database("sqlite:omni.db").await?;
+    let mut conn = get_db_connection().await?;
+    sqlx::migrate!("./migrations").run(&mut conn).await?;
+    Ok(())
 }
 
-pub async fn create_live_source_spec(live_source_spec: &LiveSourceSpec) {
-    let mut conn = get_db_connection().await;
+pub async fn create_live_source_spec(live_source_spec: &LiveSourceSpec) -> Result<()> {
+    let mut conn = get_db_connection().await?;
     sqlx::query("
         INSERT OR IGNORE INTO live_source_specs
             (uri)
@@ -25,12 +27,12 @@ pub async fn create_live_source_spec(live_source_spec: &LiveSourceSpec) {
     ")
     .bind(&live_source_spec.uri)
     .execute(&mut conn)
-    .await
-    .unwrap();
+    .await?;
+    Ok(())
 }
 
-pub async fn ingest(input_item: &InputItem) {
-    let mut conn = get_db_connection().await;
+pub async fn ingest(input_item: &InputItem) -> Result<()> {
+    let mut conn = get_db_connection().await?;
     sqlx::query("
         INSERT OR IGNORE INTO input_items
             (uri, live_source_uri, text, vision)
@@ -42,6 +44,6 @@ pub async fn ingest(input_item: &InputItem) {
     .bind(&input_item.text)
     .bind(&input_item.vision)
     .execute(&mut conn)
-    .await
-    .unwrap();
+    .await?;
+    Ok(())
 }


### PR DESCRIPTION
methods now return Result. now ingesters and digest models can give errors without panicking.

we're using anyhow crate's Error type

state module also now returns errors instead of panicking. ingesters probably can't do anything about those errors, so they should just propagate the error to the `watch` caller